### PR TITLE
nytimes.com Presence

### DIFF
--- a/websites/T/The New York Times/dist/metadata.json
+++ b/websites/T/The New York Times/dist/metadata.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schemas.premid.app/metadata/1.3",
+    "author": {
+      "name": "John Smith",
+      "id": "233950379065212938"
+    },
+    "service": "The New York Times",
+    "description": {
+      "en": "The New York Times is an American daily newspaper based in New York City with a worldwide readership. Founded in 1851, the Times has since won 130 Pulitzer Prizes, and has long been regarded within the industry as a national 'newspaper of record'. It is ranked 18th in the world by circulation and 3rd in the U.S."
+    },
+    "url": "www.nytimes.com",
+    "version": "1.0.0",
+    "logo": "https://i.imgur.com/e5xEpfu.jpg",
+    "thumbnail": "https://i.imgur.com/p8luyGx.png",
+    "color": "#ffffff",
+    "tags": ["news", "articles"],
+    "category": "other",
+    "settings": [
+      {
+        "id": "privacy",
+        "title": "Privacy Mode",
+        "icon": "fad fa-user-secret",
+        "value": false
+      }
+    ]
+}

--- a/websites/T/The New York Times/dist/presence.js
+++ b/websites/T/The New York Times/dist/presence.js
@@ -1,0 +1,72 @@
+const presence = new Presence({
+    clientId: "813781191308083239"
+});
+var elapsed;
+presence.on("UpdateData", async () => {
+    let details, state;
+    const title = document.title;
+    var privacy = await presence.getSetting("privacy");
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    elapsed = Math.floor(Date.now() / 1000);
+    if (privacy) {
+        details = "Vewing a Page";
+        state = "";
+    }
+    else {
+        if (window.location.href == "https://www.nytimes.com/") {
+            details = "Vewing Home Page";
+            state = "";
+        }
+        else if (document.location.pathname.includes("/interactive/")) {
+            details = "Viewing an Interactive: ";
+            state = title.replace(" - The New York Times", "");
+        }
+        else if (document.location.pathname.includes("/section/") || document.location.pathname.includes("/spotlight/podcasts")) {
+            details = "Viewing a Section Page: ";
+            state = title.replace(" - The New York Times", "");
+        }
+        else if (document.location.pathname.includes("/destination/")) {
+            details = "Viewing a Destination Page: ";
+            state = title.replace(" - The New York Times", "");
+        }
+        else if (document.location.pathname.includes("/reviews/")) {
+            details = "Viewing a Review Page: ";
+            state = title.replace(" - The New York Times", "");
+        }
+        else if (document.location.pathname.includes("/column/")) {
+            details = "Viewing a Column Page: ";
+            state = title.replace(" - The New York Times", "");
+        }
+        else if (document.location.pathname.includes("/search")) {
+            details = "Searching for:";
+            state = urlParams.get('query');
+        }
+        else if (document.location.pathname.includes("/video/")) {
+            details = "Viewing a Video Section: ";
+            state = title.replace(" - The New York Times", "");
+        }
+        else if (document.location.pathname.includes("/podcasts/the-daily/")) {
+            details = "Viewing a Podcast: ";
+            state = "The Daily: " + title.replace(" - The New York Times", "");
+        }
+        else {
+            details = "Viewing an Article: ";
+            state = title.replace(" - The New York Times", "");
+        }
+    }
+    var data = {
+        details: details,
+        state: state,
+        largeImageKey: "logo",
+        startTimestamp: elapsed
+    };
+    if (data.details == null) {
+        presence.setTrayTitle();
+        presence.setActivity();
+    }
+    else {
+        presence.setTrayTitle(data.state);
+        presence.setActivity(data);
+    }
+});

--- a/websites/T/The New York Times/presence.ts
+++ b/websites/T/The New York Times/presence.ts
@@ -1,0 +1,71 @@
+const presence = new Presence({
+    clientId: "813781191308083239"
+});
+
+var elapsed;
+
+presence.on("UpdateData", async () => {
+
+    let details, state;
+    const title = document.title;
+    var privacy = await presence.getSetting("privacy")
+
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+
+    elapsed = Math.floor(Date.now() / 1000);
+    if (privacy) {
+      details = "Vewing a Page";
+      state = "";
+    } else {
+      if (window.location.href == "https://www.nytimes.com/") {
+      details = "Vewing Home Page";
+      state = "";
+    } else if (document.location.pathname.includes("/interactive/")) {
+      details = "Viewing an Interactive: ";
+      state = title.replace(" - The New York Times", "");
+    } else if (document.location.pathname.includes("/section/") || document.location.pathname.includes("/spotlight/podcasts")) {
+      details = "Viewing a Section Page: ";
+      state = title.replace(" - The New York Times", "");
+    } else if (document.location.pathname.includes("/destination/")) {
+      details = "Viewing a Destination Page: ";
+      state = title.replace(" - The New York Times", "");
+    } else if (document.location.pathname.includes("/reviews/")) {
+      details = "Viewing a Review Page: ";
+      state = title.replace(" - The New York Times", "");
+    } else if (document.location.pathname.includes("/column/")) {
+      details = "Viewing a Column Page: ";
+      state = title.replace(" - The New York Times", "");
+    } else if (document.location.pathname.includes("/search")) {
+      details = "Searching for:";
+      state = urlParams.get('query');
+    } else if (document.location.pathname.includes("/video/")) {
+      details = "Viewing a Video Section: ";
+      state = title.replace(" - The New York Times", "");
+    } else if (document.location.pathname.includes("/podcasts/the-daily/")) {
+      details = "Viewing a Podcast: ";
+      state = "The Daily: " + title.replace(" - The New York Times", "");
+    } else {
+    details = "Viewing an Article: ";
+    state = title.replace(" - The New York Times", "");
+  }
+    }
+    
+  
+    var data: PresenceData = {
+      details: details,
+      state: state,
+      largeImageKey: "logo",
+      startTimestamp: elapsed
+    };
+
+    if (data.details == null) {
+      //This will fire if you do not set presence details
+      presence.setTrayTitle(); //Clears the tray title for mac users
+      presence.setActivity(); /*Update the presence with no data, therefore clearing it and making the large image the Discord Application icon, and the text the Discord Application name*/
+    } else {
+      //This will fire if you set presence details
+      presence.setTrayTitle(data.state);
+      presence.setActivity(data); //Update the presence with all the values from the presenceData object
+    }
+});

--- a/websites/T/The New York Times/tsconfig.json
+++ b/websites/T/The New York Times/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./dist/"
+    }
+}


### PR DESCRIPTION
[New York Times](https://www.nytimes.com)
<img width="1387" alt="Screenshot 2021-02-24 at 10 55 56 PM" src="https://user-images.githubusercontent.com/58304175/109019681-2b91b800-76f4-11eb-81d9-16ba03142109.png">
<img width="1399" alt="Screenshot 2021-02-24 at 10 56 11 PM" src="https://user-images.githubusercontent.com/58304175/109019695-31879900-76f4-11eb-9fab-3d96ada4b4b0.png">
<img width="1396" alt="Screenshot 2021-02-24 at 10 56 34 PM" src="https://user-images.githubusercontent.com/58304175/109019701-32202f80-76f4-11eb-963c-f44db1f3d9c8.png">
<img width="1406" alt="Screenshot 2021-02-24 at 10 56 53 PM" src="https://user-images.githubusercontent.com/58304175/109019705-33515c80-76f4-11eb-9148-1709d7a60041.png">
